### PR TITLE
Update shown JDA-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ public class Echo implements Command {
 <br>
 <h4>Use JDA-Command in your projects today!</h4>
 
-The current promoted version is 1.1.2
+The current promoted version is 1.1.2  
+JDAs current stable version is 3.8.3_460
 
 <h5>Maven</h5>
 
@@ -59,7 +60,7 @@ The current promoted version is 1.1.2
 <dependency>
     <groupId>net.dv8tion</groupId>
     <artifactId>JDA</artifactId>
-    <version>3.6.0_359</version>
+    <version>3.8.3_460</version>
 </dependency>
 ```
 
@@ -77,6 +78,6 @@ dependencies {
     //JDA-Command dependency
     compile 'com.github.rainestormee:JDA-Command:1.1.2'
     //JDA dependency
-    compile group: 'net.dv8tion', name: 'JDA', version: '3.6.0_359'
+    compile group: 'net.dv8tion', name: 'JDA', version: '3.8.3_460'
 }
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ public class Echo implements Command {
 <h4>Use JDA-Command in your projects today!</h4>
 
 The current promoted version is 1.1.2  
-JDAs current stable version is 3.8.3_460
+JDAs current stable version is 3.8.3_463
 
 <h5>Maven</h5>
 
@@ -60,7 +60,7 @@ JDAs current stable version is 3.8.3_460
 <dependency>
     <groupId>net.dv8tion</groupId>
     <artifactId>JDA</artifactId>
-    <version>3.8.3_460</version>
+    <version>3.8.3_463</version>
 </dependency>
 ```
 
@@ -78,6 +78,6 @@ dependencies {
     //JDA-Command dependency
     compile 'com.github.rainestormee:JDA-Command:1.1.2'
     //JDA dependency
-    compile group: 'net.dv8tion', name: 'JDA', version: '3.8.3_460'
+    compile group: 'net.dv8tion', name: 'JDA', version: '3.8.3_463'
 }
 ```


### PR DESCRIPTION
JDAs latest stable version in 3.x is higher than the one listed here in the readme.

While we can assume, that people are actually smart and find out, that they have to update JDAs version, we still should update it for *those* people that don't think about the fact, that the version in the readme could actually be outdated.
Also as of now does JDAs readme show version 4.ALPHA.x which isn't compatible with the latest available release of jda-command (Unless there's a dev-build available that can be used with JDA V4)